### PR TITLE
Handle generators better.

### DIFF
--- a/src/hw/object_dict.py
+++ b/src/hw/object_dict.py
@@ -1,3 +1,5 @@
+import inspect
+
 NoneType = type(None)
 
 
@@ -25,7 +27,7 @@ class ObjectDict(dict):
             return arg
         elif isinstance(arg, list):
             return list(ObjectDict(x) for x in arg)
-        elif isinstance(arg, dict):
+        elif isinstance(arg, dict) or inspect.isgenerator(arg):
             return super().__new__(cls, arg)
         else:
             raise ValueError(f"{type(arg)} objects cannot be ObjectDicts")
@@ -40,7 +42,11 @@ class ObjectDict(dict):
             return  # Assume existing ObjectDicts do not need re-initialising
         if arg is self.sentinel:  # Called without args
             arg = {}
-        for (k, v) in arg.items():
+
+        # Allows the underlying dict class to handle the arg as it usually would
+        super(ObjectDict, self).__init__(arg)
+
+        for (k, v) in self.items():
             self[k] = ObjectDict(v)
 
     def __getattr__(self, name: str):

--- a/tests/test_object_dict.py
+++ b/tests/test_object_dict.py
@@ -1,6 +1,5 @@
 import pytest
 from hw import ObjectDict
-from hw.object_dict import NoneType
 
 
 @pytest.mark.parametrize(
@@ -79,6 +78,21 @@ def test_no_args():
 def test_invalid_value():
     with pytest.raises(ValueError):
         ObjectDict(object())
+
+
+def test_generators():
+    mydict = {"a": "b", "c": "d"}
+    # This handles a generator in the same way a dict() does if it was passed
+    # a dict generator
+    od_1 = ObjectDict((k, v) for k, v in mydict.items())
+    assert od_1 == mydict
+
+    mylist = ["a", "b", "c", "d"]
+
+    with pytest.raises(ValueError):
+        # This errors in the same way as a dict() does if it was passed a list
+        # generator
+        ObjectDict(x for x in mylist)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We discovered from playing around with `dataclasses` that if a generator was passed in, that ObjectDict would handle it differently to how dict() handled it.  Therefore, modify the `__new__` method slightly to handle generators and also change `__init__` to iterate through `self` when building the ObjectDict.

  This means that the value for `arg` can be treated the same as if ObjectDict were a normal dict (raising the same error if necessary) while still providing the ObjectDict functionality.  This also has the benefit of us being able to handle different types more easily in the future while keeping as similar functionality as `dict` as possible